### PR TITLE
custom.js: Navigation durch Mobilenav erweitert und aktualisiert

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # html5-framework
 HTML & CSS-Boilerplate für Projekte bei backslash.
 
+## [2.0.1] - 2021-10-15
+
+### Added
+- custom.js: Ergänzung in der Mobilenav, dass man mit Shift-Tab beim fokussierten Button, bei geöffnetem Menu, auf den letzten Menueintrag springt
+
+### Changed
+- custom.js: Veraltete Funktion `keyCode` mit `key` ersetzt.
+- custom.js: Abfrage, dass Shift nicht gedrückt wird, bei dem normalen Tab-Listener ergänzt
+
+
 ## [2.0] - 2021-10-12
 
 ### Added

--- a/js/custom.js
+++ b/js/custom.js
@@ -37,14 +37,25 @@ $(document).ready(function(){
         // close by pressing ESC
         // loop through menu by tab
         $(selectors.navContainer + ', ' + selectors.navButton).keydown(function(e) {
-            if (e.keyCode === 27) {
+            // get last link in Menu
+            const lastLinkInList = $(selectors.navList).find('li:last > *:last-child')[0];
+            // close menu with escape and focus button
+            if (e.key === 'Escape') {
                 toggleMenu(selectors.navContainer, selectors.navList, selectors.navButton, true);
                 $(selectors.navButton).focus();
                 return false;
-            } else if (e.keyCode === 9) {
-                if (e.target === $(selectors.navList).find('li:last > *:last-child')[0]) {
+            // go to button clicking tab and last link focused
+            } else if (!e.shiftKey && e.key === 'Tab') {
+                if (e.target === lastLinkInList) {
                     e.preventDefault;
                     $(selectors.navButton).focus();
+                    return false;
+                }
+            // go to last link when clicking shift-tab, open menu and button focused
+            } else if (e.shiftKey && e.key === 'Tab') {
+                if ($(e.target).hasClass(selectors.navButton.substring(1)) && $(selectors.navContainer).is(':visible')) {
+                    e.preventDefault;
+                    lastLinkInList.focus();
                     return false;
                 }
             }


### PR DESCRIPTION
Added
- custom.js: Ergänzung in der Mobilenav, dass man mit Shift-Tab beim fokussierten Button, bei geöffnetem Menu, auf den letzten Menueintrag springt

Changed
- custom.js: Veraltete Funktion keyCode mit key ersetzt.
- custom.js: Abfrage, dass Shift nicht gedrückt wird, bei dem normalen Tab-Listener ergänzt