### PR TITLE
Prevent A11yDialog and MobileMenu from opening simultaneously

### DIFF
--- a/js/custom.js
+++ b/js/custom.js
@@ -50,6 +50,9 @@
                 this.toggle(true);
             }
             setListeners() {
+                document.addEventListener("govisA11yDropdownOpen", (() => {
+                    if (this.isActive) this.toggle(true);
+                }));
                 [ this.button, this.background ].forEach((element => {
                     element && element.addEventListener("click", (e => {
                         e.preventDefault();
@@ -75,6 +78,7 @@
                     this.slider.up();
                     this.animate.animate(this.background, true, getBackgroundFrames);
                 } else {
+                    document.dispatchEvent(new CustomEvent("govisA11yDropdownClose"));
                     html.classList.add(classes.headActive);
                     this.button.classList.add(classes.buttonActive);
                     this.animate.animate(this.background, false, getBackgroundFrames);


### PR DESCRIPTION
Currently, opening a new A11yDialog closes any previously opened A11yDialog.
The same behavior should also apply between A11yDialog and MobileMenu -  opening one should automatically close the other if it is already open.